### PR TITLE
Use java 12 for Ubuntu 14.04 build

### DIFF
--- a/Ubuntu14.04/Dockerfile
+++ b/Ubuntu14.04/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "deb http://ppa.launchpad.net/linuxuprising/java/ubuntu bionic main" | 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 73C3DB2A
 RUN echo debconf shared/accepted-oracle-license-v1-2 select true | debconf-set-selections
 RUN apt-get update
-RUN apt-get install -y oracle-java11-installer
+RUN apt-get install -y oracle-java12-installer
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 RUN apt-get update && apt-get install -y nodejs


### PR DESCRIPTION
Seems installing java 11 is broken.
Cause
```
No /var/cache/oracle-jdk11-installer/wgetrc file found.                                                                                                                                                                                                                                              
Creating /var/cache/oracle-jdk11-installer/wgetrc and                                                                                                                                                                                                                                                
using default oracle-java11-installer wgetrc settings for it.                                                                                                                                                                                                                                        
Downloading Oracle Java 11...                                                                                                                                                                                                                                                                        
--2019-06-25 09:23:41--  http://download.oracle.com/otn-pub/java/jdk/11.0.2+9/f51449fcd52f4d52b93a989c5c56ed3c/jdk-11.0.2_linux-x64_bin.tar.gz                                                                                                                                                       
Resolving download.oracle.com (download.oracle.com)... 23.40.96.162                                                                                                                                                                                                                                  
Connecting to download.oracle.com (download.oracle.com)|23.40.96.162|:80... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: https://edelivery.oracle.com/otn-pub/java/jdk/11.0.2+9/f51449fcd52f4d52b93a989c5c56ed3c/jdk-11.0.2_linux-x64_bin.tar.gz [following]
--2019-06-25 09:23:42--  https://edelivery.oracle.com/otn-pub/java/jdk/11.0.2+9/f51449fcd52f4d52b93a989c5c56ed3c/jdk-11.0.2_linux-x64_bin.tar.gz
Resolving edelivery.oracle.com (edelivery.oracle.com)... 23.43.64.234, 2a02:26f0:a1:581::366, 2a02:26f0:a1:598::366
Connecting to edelivery.oracle.com (edelivery.oracle.com)|23.43.64.234|:443... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: http://download.oracle.com/otn-pub/java/jdk/11.0.2+9/f51449fcd52f4d52b93a989c5c56ed3c/jdk-11.0.2_linux-x64_bin.tar.gz?AuthParam=1561454742_595e9dfad45fa8c121049444ae8907dc [following]
--2019-06-25 09:23:42--  http://download.oracle.com/otn-pub/java/jdk/11.0.2+9/f51449fcd52f4d52b93a989c5c56ed3c/jdk-11.0.2_linux-x64_bin.tar.gz?AuthParam=1561454742_595e9dfad45fa8c121049444ae8907dc
Connecting to download.oracle.com (download.oracle.com)|23.40.96.162|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://download.oracle.com/otn-pub/java/jdk/11.0.2+9/f51449fcd52f4d52b93a989c5c56ed3c/jdk-11.0.2_linux-x64_bin.tar.gz?AuthParam=1561454742_595e9dfad45fa8c121049444ae8907dc [following]
--2019-06-25 09:23:42--  https://download.oracle.com/otn-pub/java/jdk/11.0.2+9/f51449fcd52f4d52b93a989c5c56ed3c/jdk-11.0.2_linux-x64_bin.tar.gz?AuthParam=1561454742_595e9dfad45fa8c121049444ae8907dc
Connecting to download.oracle.com (download.oracle.com)|23.40.96.162|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2019-06-25 09:23:43 ERROR 404: Not Found.

download failed
Oracle JDK 11 is NOT installed.
dpkg: error processing package oracle-java11-installer (--configure):
 subprocess installed post-installation script returned error exit status 1
Errors were encountered while processing:
 oracle-java11-installer
E: Sub-process /usr/bin/dpkg returned an error code (1)
The command '/bin/sh -c apt-get install -y oracle-java11-installer' returned a non-zero code: 100
```
On install of `apt-get install -y oracle-java11-installer`
java 12 seems fine for a time