### PR TITLE
java 12 is not aviable now on Ubuntu 14.04

### DIFF
--- a/Ubuntu14.04/Dockerfile
+++ b/Ubuntu14.04/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "deb http://ppa.launchpad.net/linuxuprising/java/ubuntu bionic main" | 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 73C3DB2A
 RUN echo debconf shared/accepted-oracle-license-v1-2 select true | debconf-set-selections
 RUN apt-get update
-RUN apt-get install -y oracle-java12-installer
+RUN apt-get install -y oracle-java13-installer
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 RUN apt-get update && apt-get install -y nodejs


### PR DESCRIPTION
But java 13 is aviable
See:
https://launchpad.net/~linuxuprising/+archive/ubuntu/java
![image](https://user-images.githubusercontent.com/668524/69494644-2f220800-0ecf-11ea-899f-7f6e98744afd.png)
